### PR TITLE
feat: support date objects everywhere

### DIFF
--- a/docs/GGanttChart.md
+++ b/docs/GGanttChart.md
@@ -8,7 +8,7 @@ The main component of Vue Ganttastic. Represents an entire chart and is meant to
 | `precision` | string? | `"hour"` | Display precision of the time-axis. Possible values: `hour`, `day` and `month`. |
 | `bar-start` | string | | Name of the property in bar objects that represents the start date.
 | `bar-end` | string  | | Name of the property in bar objects that represents the end date .
-| `date-format` | string \| false \| undefined  | `"YYYY-MM-DD HH:mm"` | Datetime string format of `chart-start`, `chart-end` and the values of the `bar-start`, `bar-end` properties in bar objects. See [Day.js format tokens](https://day.js.org/docs/en/parse/string-format). If you want to use Javascript Date set to `false`.
+| `date-format` | string \| false  | `"YYYY-MM-DD HH:mm"` | Datetime string format of `chart-start`, `chart-end` and the values of the `bar-start`, `bar-end` properties in bar objects. See [Day.js format tokens](https://day.js.org/docs/en/parse/string-format). If the aforementioned properties are native JavaScript [Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) objects in your use case, pass `false`.
 | `width` | string? | `"100%"` | Width of the chart (e.g. `80%` or `800px`)
 | `hide-timeaxis` | boolean? | `false` | Toggle visibility of the time axis.
 | `color-scheme` | string \| ColorScheme | `"default"` | Color scheme (theme) of the chart. Either use the name of one of the predefined schemes or pass a color-scheme-object of your own. See [color schemes](#color-schemes).

--- a/docs/GGanttChart.md
+++ b/docs/GGanttChart.md
@@ -8,7 +8,7 @@ The main component of Vue Ganttastic. Represents an entire chart and is meant to
 | `precision` | string? | `"hour"` | Display precision of the time-axis. Possible values: `hour`, `day` and `month`. |
 | `bar-start` | string | | Name of the property in bar objects that represents the start date.
 | `bar-end` | string  | | Name of the property in bar objects that represents the end date .
-| `date-format` | string?  | `"YYYY-MM-DD HH:mm"` | Datetime string format of `chart-start`, `chart-end` and the values of the `bar-start`, `bar-end` properties in bar objects. See [Day.js format tokens](https://day.js.org/docs/en/parse/string-format).
+| `date-format` | string \| false \| undefined  | `"YYYY-MM-DD HH:mm"` | Datetime string format of `chart-start`, `chart-end` and the values of the `bar-start`, `bar-end` properties in bar objects. See [Day.js format tokens](https://day.js.org/docs/en/parse/string-format). If you want to use Javascript Date set to `false`.
 | `width` | string? | `"100%"` | Width of the chart (e.g. `80%` or `800px`)
 | `hide-timeaxis` | boolean? | `false` | Toggle visibility of the time axis.
 | `color-scheme` | string \| ColorScheme | `"default"` | Color scheme (theme) of the chart. Either use the name of one of the predefined schemes or pass a color-scheme-object of your own. See [color schemes](#color-schemes).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@infectoone/vue-ganttastic",
-  "version": "2.1.1",
+  "version": "2.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@infectoone/vue-ganttastic",
-      "version": "2.1.1",
+      "version": "2.1.3",
       "license": "MIT",
       "dependencies": {
         "@vueuse/core": "^9.1.1"

--- a/src/components/GGanttBar.vue
+++ b/src/components/GGanttBar.vue
@@ -33,7 +33,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, toRefs, watch, type CSSProperties, onMounted, inject } from "vue"
+import { computed, ref, toRefs, watch, onMounted, inject } from "vue"
 
 import useBarDragManagement from "../composables/useBarDragManagement.js"
 import useTimePositionMapping from "../composables/useTimePositionMapping.js"

--- a/src/components/GGanttBar.vue
+++ b/src/components/GGanttBar.vue
@@ -2,7 +2,15 @@
   <div
     :id="barConfig.id"
     class="g-gantt-bar"
-    :style="barStyle"
+    :style="{
+      ...barConfig.style,
+      position: 'absolute',
+      top: `${rowHeight * 0.1}px`,
+      left: `${xStart}px`,
+      width: `${xEnd - xStart}px`,
+      height: `${rowHeight * 0.8}px`,
+      zIndex: isDragging ? 3 : 2
+    }"
     @mousedown="onMouseEvent"
     @click="onMouseEvent"
     @dblclick="onMouseEvent"
@@ -107,17 +115,6 @@ onMounted(() => {
   )
 })
 
-const barStyle = computed(() => {
-  return {
-    ...barConfig.value.style,
-    position: "absolute",
-    top: `${rowHeight.value * 0.1}px`,
-    left: `${xStart.value}px`,
-    width: `${xEnd.value - xStart.value}px`,
-    height: `${rowHeight.value * 0.8}px`,
-    zIndex: isDragging.value ? 3 : 2
-  } as CSSProperties
-})
 </script>
 
 <style>

--- a/src/components/GGanttBar.vue
+++ b/src/components/GGanttBar.vue
@@ -92,10 +92,10 @@ const onMouseEvent = (e: MouseEvent) => {
     prepareForDrag()
   }
   const barContainer = barContainerEl?.value?.getBoundingClientRect()
-  let datetime
-  if (barContainer) {
-    datetime = mapPositionToTime(e.clientX - barContainer.left)
+  if (!barContainer) {
+    return
   }
+  const datetime = mapPositionToTime(e.clientX - barContainer.left)
   emitBarEvent(e, bar.value, datetime)
 }
 
@@ -114,7 +114,6 @@ onMounted(() => {
     { deep: true, immediate: true }
   )
 })
-
 </script>
 
 <style>

--- a/src/components/GGanttBarTooltip.vue
+++ b/src/components/GGanttBarTooltip.vue
@@ -11,7 +11,7 @@
         }"
       >
         <div class="g-gantt-tooltip-color-dot" :style="{ background: dotColor }" />
-        <slot>
+        <slot :bar="bar" :bar-start="barStartRaw" :bar-end="barEndRaw">
           {{ tooltipContent }}
         </slot>
       </div>
@@ -35,12 +35,12 @@ const TOOLTIP_FORMATS = {
 const DEFAULT_DOT_COLOR = "cadetblue"
 
 const props = defineProps<{
-  bar?: GanttBarObject
+  bar: GanttBarObject | undefined
   modelValue: boolean
 }>()
 
 const { bar } = toRefs(props)
-const config = provideConfig()
+const { precision, font, barStart, barEnd, rowHeight } = provideConfig()
 
 const tooltipTop = ref("0px")
 const tooltipLeft = ref("0px")
@@ -59,7 +59,6 @@ watch(
       top: 0,
       left: 0
     }
-    const { rowHeight } = config
     const leftValue = Math.max(left, 10)
     tooltipTop.value = `${top + rowHeight.value - 10}px`
     tooltipLeft.value = `${leftValue}px`
@@ -70,14 +69,17 @@ watch(
 const dotColor = computed(() => bar?.value?.ganttBarConfig.style?.background || DEFAULT_DOT_COLOR)
 
 const { toDayjs } = useDayjsHelper()
-const { precision, font } = config
+
+const barStartRaw = computed(() => bar.value?.[barStart.value])
+const barEndRaw = computed(() => bar.value?.[barEnd.value])
+
 const tooltipContent = computed(() => {
-  const format = TOOLTIP_FORMATS[precision.value]
   if (!bar?.value) {
     return ""
   }
-  const barStartFormatted = toDayjs(bar.value, "start").format(format)
-  const barEndFormatted = toDayjs(bar.value, "end").format(format)
+  const format = TOOLTIP_FORMATS[precision.value]
+  const barStartFormatted = toDayjs(barStartRaw.value).format(format)
+  const barEndFormatted = toDayjs(barEndRaw.value).format(format)
   return `${barStartFormatted} \u2013 ${barEndFormatted}`
 })
 </script>

--- a/src/components/GGanttChart.vue
+++ b/src/components/GGanttChart.vue
@@ -52,12 +52,12 @@ import type { GanttBarObject } from "../types"
 import { useElementSize } from "@vueuse/core"
 
 export interface GGanttChartProps {
-  chartStart: string
-  chartEnd: string
+  chartStart: string | Date
+  chartEnd: string | Date
   precision?: "hour" | "day" | "month"
   barStart: string
   barEnd: string
-  dateFormat?: string
+  dateFormat: string | false | undefined
   width?: string
   hideTimeaxis?: boolean
   colorScheme?: ColorSchemeKey | ColorScheme
@@ -78,7 +78,6 @@ export type GGanttChartConfig = ToRefs<Required<GGanttChartProps>> & {
 }
 
 const props = withDefaults(defineProps<GGanttChartProps>(), {
-  dateFormat: "YYYY-MM-DD HH:mm",
   precision: "day",
   width: "100%",
   hideTimeaxis: false,
@@ -92,10 +91,13 @@ const props = withDefaults(defineProps<GGanttChartProps>(), {
 })
 
 const emit = defineEmits<{
-  (e: "click-bar", value: { bar: GanttBarObject; e: MouseEvent; datetime?: string }): void
-  (e: "mousedown-bar", value: { bar: GanttBarObject; e: MouseEvent; datetime?: string }): void
-  (e: "mouseup-bar", value: { bar: GanttBarObject; e: MouseEvent; datetime?: string }): void
-  (e: "dblclick-bar", value: { bar: GanttBarObject; e: MouseEvent; datetime?: string }): void
+  (e: "click-bar", value: { bar: GanttBarObject; e: MouseEvent; datetime?: string | Date }): void
+  (
+    e: "mousedown-bar",
+    value: { bar: GanttBarObject; e: MouseEvent; datetime?: string | Date }
+  ): void
+  (e: "mouseup-bar", value: { bar: GanttBarObject; e: MouseEvent; datetime?: string | Date }): void
+  (e: "dblclick-bar", value: { bar: GanttBarObject; e: MouseEvent; datetime?: string | Date }): void
   (e: "mouseenter-bar", value: { bar: GanttBarObject; e: MouseEvent }): void
   (e: "mouseleave-bar", value: { bar: GanttBarObject; e: MouseEvent }): void
   (e: "dragstart-bar", value: { bar: GanttBarObject; e: MouseEvent }): void
@@ -108,7 +110,10 @@ const emit = defineEmits<{
       movedBars?: Map<GanttBarObject, { oldStart: string; oldEnd: string }>
     }
   ): void
-  (e: "contextmenu-bar", value: { bar: GanttBarObject; e: MouseEvent; datetime?: string }): void
+  (
+    e: "contextmenu-bar",
+    value: { bar: GanttBarObject; e: MouseEvent; datetime?: string | Date }
+  ): void
 }>()
 
 const { width, font, colorScheme } = toRefs(props)
@@ -168,7 +173,7 @@ const clearTooltip = () => {
 const emitBarEvent = (
   e: MouseEvent,
   bar: GanttBarObject,
-  datetime?: string,
+  datetime?: string | Date,
   movedBars?: Map<GanttBarObject, { oldStart: string; oldEnd: string }>
 ) => {
   switch (e.type) {

--- a/src/components/GGanttChart.vue
+++ b/src/components/GGanttChart.vue
@@ -49,6 +49,7 @@ import { colorSchemes, type ColorScheme } from "../color-schemes.js"
 import type { ColorSchemeKey } from "../color-schemes.js"
 import { CHART_ROWS_KEY, CONFIG_KEY, EMIT_BAR_EVENT_KEY } from "../provider/symbols.js"
 import type { GanttBarObject } from "../types"
+import { DEFAULT_DATE_FORMAT } from "../composables/useDayjsHelper"
 import { useElementSize } from "@vueuse/core"
 
 export interface GGanttChartProps {
@@ -57,7 +58,7 @@ export interface GGanttChartProps {
   precision?: "hour" | "day" | "month"
   barStart: string
   barEnd: string
-  dateFormat: string | false | undefined
+  dateFormat?: string | false
   width?: string
   hideTimeaxis?: boolean
   colorScheme?: ColorSchemeKey | ColorScheme
@@ -78,6 +79,7 @@ export type GGanttChartConfig = ToRefs<Required<GGanttChartProps>> & {
 }
 
 const props = withDefaults(defineProps<GGanttChartProps>(), {
+  dateFormat: DEFAULT_DATE_FORMAT,
   precision: "day",
   width: "100%",
   hideTimeaxis: false,

--- a/src/components/GGanttRow.vue
+++ b/src/components/GGanttRow.vue
@@ -39,7 +39,7 @@ const props = defineProps<{
 }>()
 
 const emit = defineEmits<{
-  (e: "drop", value: { e: MouseEvent; datetime: string }): void
+  (e: "drop", value: { e: MouseEvent; datetime: string | Date }): void
 }>()
 
 const { rowHeight, colors } = provideConfig()

--- a/src/composables/createBarDrag.ts
+++ b/src/composables/createBarDrag.ts
@@ -1,4 +1,4 @@
-import {ref } from "vue"
+import { ref } from "vue"
 import type { GGanttChartConfig } from "../components/GGanttChart.vue"
 import provideConfig from "../provider/provideConfig.js"
 

--- a/src/composables/useBarDragManagement.ts
+++ b/src/composables/useBarDragManagement.ts
@@ -15,7 +15,7 @@ export default function useBarDragManagement() {
 
   const movedBarsInDrag = new Map<GanttBarObject, { oldStart: string; oldEnd: string }>()
 
-  const { toDayjs } = useDayjsHelper()
+  const { toDayjs, format } = useDayjsHelper()
 
   const initDragOfBar = (bar: GanttBarObject, e: MouseEvent) => {
     const { initDrag } = createBarDrag(bar, onDrag, onEndDrag, config)
@@ -63,17 +63,19 @@ export default function useBarDragManagement() {
       switch (overlapType) {
         case "left":
           minuteDiff = overlapBarEnd.diff(currentBarStart, "minutes", true)
-          overlapBar[barEnd.value] = currentBarStart.format(dateFormat.value)
-          overlapBar[barStart.value] = overlapBarStart
-            .subtract(minuteDiff, "minutes")
-            .format(dateFormat.value)
+          overlapBar[barEnd.value] = format(currentBar[barStart.value], dateFormat.value)
+          overlapBar[barStart.value] = format(
+            overlapBarStart.subtract(minuteDiff, "minutes"),
+            dateFormat.value
+          )
           break
         case "right":
           minuteDiff = currentBarEnd.diff(overlapBarStart, "minutes", true)
-          overlapBar[barStart.value] = currentBarEnd.format(dateFormat.value)
-          overlapBar[barEnd.value] = overlapBarEnd
-            .add(minuteDiff, "minutes")
-            .format(dateFormat.value)
+          overlapBar[barStart.value] = format(currentBarEnd, dateFormat.value)
+          overlapBar[barEnd.value] = format(
+            overlapBarEnd.add(minuteDiff, "minutes"),
+            dateFormat.value
+          )
           break
         default:
           console.warn(
@@ -139,16 +141,21 @@ export default function useBarDragManagement() {
   const moveBarByMinutes = (bar: GanttBarObject, minutes: number, direction: "left" | "right") => {
     switch (direction) {
       case "left":
-        bar[barStart.value] = toDayjs(bar, "start")
-          .subtract(minutes, "minutes")
-          .format(dateFormat.value)
-        bar[barEnd.value] = toDayjs(bar, "end")
-          .subtract(minutes, "minutes")
-          .format(dateFormat.value)
+        bar[barStart.value] = format(
+          toDayjs(bar, "start").subtract(minutes, "minutes"),
+          dateFormat.value
+        )
+        bar[barEnd.value] = format(
+          toDayjs(bar, "end").subtract(minutes, "minutes"),
+          dateFormat.value
+        )
         break
       case "right":
-        bar[barStart.value] = toDayjs(bar, "start").add(minutes, "minutes").format(dateFormat.value)
-        bar[barEnd.value] = toDayjs(bar, "end").add(minutes, "minutes").format(dateFormat.value)
+        bar[barStart.value] = format(
+          toDayjs(bar, "start").add(minutes, "minutes"),
+          dateFormat.value
+        )
+        bar[barEnd.value] = format(toDayjs(bar, "end").add(minutes, "minutes"), dateFormat.value)
     }
     fixOverlaps(bar)
   }

--- a/src/composables/useDayjsHelper.ts
+++ b/src/composables/useDayjsHelper.ts
@@ -27,13 +27,13 @@ export default function useDayjsHelper(config: GGanttChartConfig = provideConfig
     return dayjs(value, format, true)
   }
 
-  const format = (input: string | Date | Dayjs, template?: string | false | undefined) => {
-    if (template === false) {
+  const format = (input: string | Date | Dayjs, pattern?: string | false) => {
+    if (pattern === false) {
       return input instanceof Date ? input : dayjs(input).toDate()
     }
     const inputDayjs = typeof input === "string" || input instanceof Date ? toDayjs(input) : input
 
-    return inputDayjs.format(template)
+    return inputDayjs.format(pattern)
   }
 
   return {

--- a/src/composables/useTimePositionMapping.ts
+++ b/src/composables/useTimePositionMapping.ts
@@ -6,7 +6,7 @@ import provideConfig from "../provider/provideConfig.js"
 
 export default function useTimePositionMapping(config: GGanttChartConfig = provideConfig()) {
   const { dateFormat, chartSize } = config
-  const { chartStartDayjs, chartEndDayjs, toDayjs } = useDayjsHelper(config)
+  const { chartStartDayjs, chartEndDayjs, toDayjs, format } = useDayjsHelper(config)
 
   const totalNumOfMinutes = computed(() => {
     return chartEndDayjs.value.diff(chartStartDayjs.value, "minutes")
@@ -21,7 +21,7 @@ export default function useTimePositionMapping(config: GGanttChartConfig = provi
   const mapPositionToTime = (xPos: number) => {
     const width = chartSize.width.value || 0
     const diffFromStart = (xPos / width) * totalNumOfMinutes.value
-    return chartStartDayjs.value.add(diffFromStart, "minutes").format(dateFormat.value)
+    return format(chartStartDayjs.value.add(diffFromStart, "minutes"), dateFormat.value)
   }
 
   return {

--- a/src/composables/useTimeaxisUnits.ts
+++ b/src/composables/useTimeaxisUnits.ts
@@ -32,8 +32,8 @@ export default function useTimeaxisUnits() {
   }
 
   const timeaxisUnits = computed(() => {
-    const upperUnits: { label: string; value?: string; date?: Date, width?: string }[] = []
-    const lowerUnits: { label: string; value?: string; date?: Date, width?: string }[] = []
+    const upperUnits: { label: string; value?: string; date: Date; width?: string }[] = []
+    const lowerUnits: { label: string; value?: string; date: Date; width?: string }[] = []
     const upperUnit = upperPrecision.value === "day" ? "date" : upperPrecision.value
     const lowerUnit = precision.value
     let currentUnit = chartStartDayjs.value.startOf(lowerUnit)

--- a/src/provider/symbols.ts
+++ b/src/provider/symbols.ts
@@ -7,7 +7,7 @@ export type GetChartRows = () => GanttBarObject[][]
 export type EmitBarEvent = (
   e: MouseEvent,
   bar: GanttBarObject,
-  datetime?: string,
+  datetime?: string | Date,
   movedBars?: Map<GanttBarObject, { oldStart: string; oldEnd: string }>
 ) => void
 


### PR DESCRIPTION
By allowing the new value `false` for the `dateFormat` prop we can enable the usage of date raw date values as input and disable formatting of the dates to strings.

Additionally the tooltip receives the raw bar values.