### PR TITLE
Custom html in bars

### DIFF
--- a/docs/common-use-cases.md
+++ b/docs/common-use-cases.md
@@ -50,6 +50,7 @@ For further configuration, you can add some optional properties to the nested `g
 |-----------------------|---------|-----------------------|
 | `id` | `string` | A unique string identifier for the bar.  (**mandatory**) 
 | `label` | `string?`  | Text displayed on the bar.
+| `label` | `string?`  | Optional HTML Code that will be rendered after the label (e.g. for tags). Please sanitize user input to avoid cross site scripting, if applicable.
 | `hasHandles` | `boolean?`  | Used to toggle handles on the left and right side of the bar that can be dragged to change the width of the bar. |
 | `immobile` | `boolean?`  | Used to toggle whether bar can be moved (dragged).
 | `bundle` | `string?`  | A string identifier for a bundle. A bundle is a collection of bars that are dragged simultaneously.

--- a/docs/common-use-cases.md
+++ b/docs/common-use-cases.md
@@ -46,15 +46,15 @@ Your bar objects can be of any type and contain any properties you want. The onl
 
 For further configuration, you can add some optional properties to the nested `ganttBarConfig` object:
 
-| Property name         | Type    | Description           |
-|-----------------------|---------|-----------------------|
-| `id` | `string` | A unique string identifier for the bar.  (**mandatory**) 
-| `label` | `string?`  | Text displayed on the bar.
-| `label` | `string?`  | Optional HTML Code that will be rendered after the label (e.g. for tags). Please sanitize user input to avoid cross site scripting, if applicable.
-| `hasHandles` | `boolean?`  | Used to toggle handles on the left and right side of the bar that can be dragged to change the width of the bar. |
-| `immobile` | `boolean?`  | Used to toggle whether bar can be moved (dragged).
-| `bundle` | `string?`  | A string identifier for a bundle. A bundle is a collection of bars that are dragged simultaneously.
-| `style` | `CSSStyleSheet?`  | CSS-based styling for your bar (e.g `background`, `fontSize`, `borderRadius` etc.).
+| Property name | Type    | Description           |
+|---------------|---------|-----------------------|
+| `id`          | `string` | A unique string identifier for the bar.  (**mandatory**) 
+| `label`       | `string?`  | Text displayed on the bar.
+| `html`        | `string?`  | Optional HTML Code that will be rendered after the label (e.g. for tags). Please sanitize user input to avoid cross site scripting, if applicable.
+| `hasHandles`  | `boolean?`  | Used to toggle handles on the left and right side of the bar that can be dragged to change the width of the bar. |
+| `immobile`    | `boolean?`  | Used to toggle whether bar can be moved (dragged).
+| `bundle`      | `string?`  | A string identifier for a bundle. A bundle is a collection of bars that are dragged simultaneously.
+| `style`       | `CSSStyleSheet?`  | CSS-based styling for your bar (e.g `background`, `fontSize`, `borderRadius` etc.).
 
 ## Extending the width of a bar
 Simply add `hasHandles: true` to the `ganttBarConfig` to make the bar extendable by dragging the handles on its left or right side.  

--- a/src/components/GGanttBar.vue
+++ b/src/components/GGanttBar.vue
@@ -23,6 +23,7 @@
         <div>
           {{ barConfig.label || "" }}
         </div>
+        <div v-if="barConfig.html" v-html="barConfig.html"/>
       </slot>
     </div>
     <template v-if="barConfig.hasHandles">

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ export type GanttBarObject = {
   ganttBarConfig: {
     id: string
     label?: string
+    html?: string
     hasHandles?: boolean
     immobile?: boolean
     bundle?: string


### PR DESCRIPTION
Allows custom html to be inserted into the ganttt bars. This optional HTML Code will be rendered after the label (e.g. for tags or user avatars). The possibility of cross site scripting is mentioned in my documentation change.