### PR TITLE
Fix issues, add new features.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ docs/.vitepress/temp
 docs/.vitepress/dist
 
 *.tgz
+
+# Package manager
+.npmrc

--- a/docs/GGanttChart.md
+++ b/docs/GGanttChart.md
@@ -29,6 +29,7 @@ The main component of Vue Ganttastic. Represents an entire chart and is meant to
 | `dayNameLength` | string? | `short` | Sets whether the day name is short or long eg. 'Fri' or 'Friday'. Possible values: `short`, `long`
 | `locale` | string? | `en-GB` | Used when getting the day name only.
 | `allowRightClickDragging` | boolean? | `false` | Enable or disable the ability to drag bars when right-clicking a bar. Useful if you want to use the context menu and prevent accidental bar movements.
+| `disableDragging` | boolean? | `false` | Disable dragging for all bars in the chart.
 
 
 ## Custom Events

--- a/docs/GGanttChart.md
+++ b/docs/GGanttChart.md
@@ -19,9 +19,9 @@ The main component of Vue Ganttastic. Represents an entire chart and is meant to
 | `no-overlap` | boolean? |  `false` | If `push-on-overlap` is `false`, toggle this to prevent overlaps after drag by snapping the dragged bar back to its original position.
 | `row-height` | number? | `40` | Height of each row in pixels.
 | `highlighted-units` | number[]? | `[]` | The time units specified here will be visually highlighted in the chart with a mild opaque color. Make sure to also use the `grid` prop on the chart.
-| `highlighted-days-of-week` | number[]? | When using `precision = day` or `date`, set this array to the days of the week that should be highlighted. Sunday = 0. So to highlight weekends, use `[0, 6]`. Can be combined with `highlighted-dates`. Make sure to also use the `grid` prop on the chart.
-| `highlighted-dates` | number[]? | When using `precision = day` or `date`, set this array to the dates that should be highlighted. e.g. `[1, 15, 23]` to highlight the 1st, 15th and 23rd. Can be combined with `highlighted-days-of-week`. Make sure to also use the `grid` prop on the chart.
-| `highlighted-hours` | number[]? | When using `precision = hour` set this array to the hours that should be highlighted. Make sure to also use the `grid` prop on the chart.
+| `highlighted-days-of-week` | number[]? | `[]` | When using `precision = day` or `date`, set this array to the days of the week that should be highlighted. Sunday = 0. So to highlight weekends, use `[0, 6]`. Can be combined with `highlighted-dates`. Make sure to also use the `grid` prop on the chart.
+| `highlighted-dates` | number[]? | `[]` | When using `precision = day` or `date`, set this array to the dates that should be highlighted. e.g. `[1, 15, 23]` to highlight the 1st, 15th and 23rd. Can be combined with `highlighted-days-of-week`. Make sure to also use the `grid` prop on the chart.
+| `highlighted-hours` | number[]? | `[]` | When using `precision = hour` set this array to the hours that should be highlighted. Make sure to also use the `grid` prop on the chart.
 | `font` | string | `"Helvetica"`| Font family of the chart.
 | `label-column-title` | string? | `''` | If specified, a dedicated column for the row labels will be rendered on the left side of the graph. The specified title is displayed in the upper left corner, as the column's header.
 | `label-column-width` | string? | `150px` | Width of the column containing the row labels (if `label-column-title` specified)

--- a/docs/GGanttChart.md
+++ b/docs/GGanttChart.md
@@ -18,10 +18,10 @@ The main component of Vue Ganttastic. Represents an entire chart and is meant to
 | `push-on-overlap` | boolean? | `false` | Specifies whether bars "push one another" when dragging and overlaping.
 | `no-overlap` | boolean? |  `false` | If `push-on-overlap` is `false`, toggle this to prevent overlaps after drag by snapping the dragged bar back to its original position.
 | `row-height` | number? | `40` | Height of each row in pixels.
-| `highlighted-units` | number[]? | `[]` | The time units specified here will be visually highlighted in the chart with a mild opaque color.
-| `highlighted-days-of-week` | number[]? | When using `precision = day` or `date`, set this array to the days of the week that should be highlighted. Sunday = 0. So to highlight weekends, use `[0, 6]`. Can be combined with `highlighted-dates`
-| `highlighted-dates` | number[]? | When using `precision = day` or `date`, set this array to the dates that should be highlighted. e.g. `[1, 15, 23]` to highlight the 1st, 15th and 23rd. Can be combined with `highlighted-days-of-week`.
-| `highlighted-hours` | number[]? | When using `precision = hour` set this array to the hours that should be highlighted.  
+| `highlighted-units` | number[]? | `[]` | The time units specified here will be visually highlighted in the chart with a mild opaque color. Make sure to also use the `grid` prop on the chart.
+| `highlighted-days-of-week` | number[]? | When using `precision = day` or `date`, set this array to the days of the week that should be highlighted. Sunday = 0. So to highlight weekends, use `[0, 6]`. Can be combined with `highlighted-dates`. Make sure to also use the `grid` prop on the chart.
+| `highlighted-dates` | number[]? | When using `precision = day` or `date`, set this array to the dates that should be highlighted. e.g. `[1, 15, 23]` to highlight the 1st, 15th and 23rd. Can be combined with `highlighted-days-of-week`. Make sure to also use the `grid` prop on the chart.
+| `highlighted-hours` | number[]? | When using `precision = hour` set this array to the hours that should be highlighted. Make sure to also use the `grid` prop on the chart.
 | `font` | string | `"Helvetica"`| Font family of the chart.
 | `label-column-title` | string? | `''` | If specified, a dedicated column for the row labels will be rendered on the left side of the graph. The specified title is displayed in the upper left corner, as the column's header.
 | `label-column-width` | string? | `150px` | Width of the column containing the row labels (if `label-column-title` specified)

--- a/docs/GGanttChart.md
+++ b/docs/GGanttChart.md
@@ -24,8 +24,8 @@ The main component of Vue Ganttastic. Represents an entire chart and is meant to
 | `label-column-width` | string? | `150px` | Width of the column containing the row labels (if `label-column-title` specified)
 | `showDayName` | boolean? | `true` | Adds the Day name to the timeunit axis when in `day` or `date` mode
 | `dayNameLength` | string? | `short` | Sets whether the day name is short or long eg. 'Fri' or 'Friday'. Possible values: `short`, `long`
-| `locale` | string? | 'en-GB' | Used when getting the day name only.
-| `allowRightClickDragging | boolean? | 'false' | Enable or disable the ability to drag bars when right-clicking a bar. Useful if you want to use the context menu and prevent accidental bar movements.
+| `locale` | string? | `en-GB` | Used when getting the day name only.
+| `allowRightClickDragging` | boolean? | `false` | Enable or disable the ability to drag bars when right-clicking a bar. Useful if you want to use the context menu and prevent accidental bar movements.
 
 
 ## Custom Events

--- a/docs/GGanttChart.md
+++ b/docs/GGanttChart.md
@@ -22,6 +22,9 @@ The main component of Vue Ganttastic. Represents an entire chart and is meant to
 | `font` | string | `"Helvetica"`| Font family of the chart.
 | `label-column-title` | string? | `''` | If specified, a dedicated column for the row labels will be rendered on the left side of the graph. The specified title is displayed in the upper left corner, as the column's header.
 | `label-column-width` | string? | `150px` | Width of the column containing the row labels (if `label-column-title` specified)
+| `showDayName` | boolean? | `true` | Adds the Day name to the timeunit axis when in `day` or `date` mode
+| `dayNameLength` | string? | `short` | Sets whether the day name is short or long eg. 'Fri' or 'Friday'. Possible values: `short`, `long`
+| `locale` | string? | 'en-GB' | Used when getting the day name only.
 
 
 ## Custom Events

--- a/docs/GGanttChart.md
+++ b/docs/GGanttChart.md
@@ -19,6 +19,9 @@ The main component of Vue Ganttastic. Represents an entire chart and is meant to
 | `no-overlap` | boolean? |  `false` | If `push-on-overlap` is `false`, toggle this to prevent overlaps after drag by snapping the dragged bar back to its original position.
 | `row-height` | number? | `40` | Height of each row in pixels.
 | `highlighted-units` | number[]? | `[]` | The time units specified here will be visually highlighted in the chart with a mild opaque color.
+| `highlighted-days-of-week` | number[]? | When using `precision = day` or `date`, set this array to the days of the week that should be highlighted. Sunday = 0. So to highlight weekends, use `[0, 6]`. Can be combined with `highlighted-dates`
+| `highlighted-dates` | number[]? | When using `precision = day` or `date`, set this array to the dates that should be highlighted. e.g. `[1, 15, 23]` to highlight the 1st, 15th and 23rd. Can be combined with `highlighted-days-of-week`.
+| `highlighted-hours` | number[]? | When using `precision = hour` set this array to the hours that should be highlighted.  
 | `font` | string | `"Helvetica"`| Font family of the chart.
 | `label-column-title` | string? | `''` | If specified, a dedicated column for the row labels will be rendered on the left side of the graph. The specified title is displayed in the upper left corner, as the column's header.
 | `label-column-width` | string? | `150px` | Width of the column containing the row labels (if `label-column-title` specified)

--- a/docs/GGanttChart.md
+++ b/docs/GGanttChart.md
@@ -6,31 +6,31 @@ The main component of Vue Ganttastic. Represents an entire chart and is meant to
 | `chart-start` | string | | Start date-time of the chart.
 | `chart-end` | string  | | End date-time of the chart.
 | `precision` | string? | `"hour"` | Display precision of the time-axis. Possible values: `hour`, `day`, `date`, `week` and `month`. |
-| `bar-start` | string | | Name of the property in bar objects that represents the start date.
-| `bar-end` | string  | | Name of the property in bar objects that represents the end date .
-| `date-format` | string \| false  | `"YYYY-MM-DD HH:mm"` | Datetime string format of `chart-start`, `chart-end` and the values of the `bar-start`, `bar-end` properties in bar objects. See [Day.js format tokens](https://day.js.org/docs/en/parse/string-format). If the aforementioned properties are native JavaScript [Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) objects in your use case, pass `false`.
-| `width` | string? | `"100%"` | Width of the chart (e.g. `80%` or `800px`)
-| `hide-timeaxis` | boolean? | `false` | Toggle visibility of the time axis.
-| `color-scheme` | string \| ColorScheme | `"default"` | Color scheme (theme) of the chart. Either use the name of one of the predefined schemes or pass a color-scheme-object of your own. See [color schemes](#color-schemes).
-| `grid` | string? | `false` | Toggle visibility of background grid.
-| `current-time` | boolean? | `false` | Toggle visibility of current time marker.
-| `current-time-label` | string? | `''` | Text to be displayed next to the current time marker.
-| `push-on-overlap` | boolean? | `false` | Specifies whether bars "push one another" when dragging and overlaping.
-| `no-overlap` | boolean? |  `false` | If `push-on-overlap` is `false`, toggle this to prevent overlaps after drag by snapping the dragged bar back to its original position.
-| `row-height` | number? | `40` | Height of each row in pixels.
-| `highlighted-units` | number[]? | `[]` | The time units specified here will be visually highlighted in the chart with a mild opaque color. Make sure to also use the `grid` prop on the chart.
-| `highlighted-days-of-week` | number[]? | `[]` | When using `precision = day` or `date`, set this array to the days of the week that should be highlighted. Sunday = 0. So to highlight weekends, use `[0, 6]`. Can be combined with `highlighted-dates`. Make sure to also use the `grid` prop on the chart.
-| `highlighted-dates` | number[]? | `[]` | When using `precision = day` or `date`, set this array to the dates that should be highlighted. e.g. `[1, 15, 23]` to highlight the 1st, 15th and 23rd. Can be combined with `highlighted-days-of-week`. Make sure to also use the `grid` prop on the chart.
-| `highlighted-hours` | number[]? | `[]` | When using `precision = hour` set this array to the hours that should be highlighted. Make sure to also use the `grid` prop on the chart.
-| `font` | string | `"Helvetica"`| Font family of the chart.
-| `label-column-title` | string? | `''` | If specified, a dedicated column for the row labels will be rendered on the left side of the graph. The specified title is displayed in the upper left corner, as the column's header.
-| `label-column-width` | string? | `150px` | Width of the column containing the row labels (if `label-column-title` specified)
-| `showDayName` | boolean? | `true` | Adds the Day name to the timeunit axis when in `day` or `date` mode
-| `dayNameLength` | string? | `short` | Sets whether the day name is short or long eg. 'Fri' or 'Friday'. Possible values: `short`, `long`
-| `locale` | string? | `en-GB` | Used when getting the day name only.
-| `allowRightClickDragging` | boolean? | `false` | Enable or disable the ability to drag bars when right-clicking a bar. Useful if you want to use the context menu and prevent accidental bar movements.
-| `disableDragging` | boolean? | `false` | Disable dragging for all bars in the chart.
-| `showLabelAsTooltipTitle` | boolean? | `true` | Toggles showing each bar item's label as the title in the hover tooltip. Make sure to sanitize your labels.
+| `bar-start` | string | | Name of the property in bar objects that represents the start date. |
+| `bar-end` | string  | | Name of the property in bar objects that represents the end date . |
+| `date-format` | string \| false  | `"YYYY-MM-DD HH:mm"` | Datetime string format of `chart-start`, `chart-end` and the values of the `bar-start`, `bar-end` properties in bar objects. See [Day.js format tokens](https://day.js.org/docs/en/parse/string-format). If the aforementioned properties are native JavaScript [Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) objects in your use case, pass `false`. |
+| `width` | string? | `"100%"` | Width of the chart (e.g. `80%` or `800px`) |
+| `hide-timeaxis` | boolean? | `false` | Toggle visibility of the time axis. |
+| `color-scheme` | string \| ColorScheme | `"default"` | Color scheme (theme) of the chart. Either use the name of one of the predefined schemes or pass a color-scheme-object of your own. See [color schemes](#color-schemes). |
+| `grid` | string? | `false` | Toggle visibility of background grid. |
+| `current-time` | boolean? | `false` | Toggle visibility of current time marker. |
+| `current-time-label` | string? | `''` | Text to be displayed next to the current time marker. |
+| `push-on-overlap` | boolean? | `false` | Specifies whether bars "push one another" when dragging and overlaping. |
+| `no-overlap` | boolean? |  `false` | If `push-on-overlap` is `false`, toggle this to prevent overlaps after drag by snapping the dragged bar back to its original position. |
+| `row-height` | number? | `40` | Height of each row in pixels. |
+| `highlighted-units` | number[]? | `[]` | The time units specified here will be visually highlighted in the chart with a mild opaque color. Make sure to also use the `grid` prop on the chart. |
+| `highlighted-days-of-week` | number[]? | `[]` | When using `precision = day` or `date`, set this array to the days of the week that should be highlighted. Sunday = 0. So to highlight weekends, use `[0, 6]`. Can be combined with `highlighted-dates`. Make sure to also use the `grid` prop on the chart. |
+| `highlighted-dates` | number[]? | `[]` | When using `precision = day` or `date`, set this array to the dates that should be highlighted. e.g. `[1, 15, 23]` to highlight the 1st, 15th and 23rd. Can be combined with `highlighted-days-of-week`. Make sure to also use the `grid` prop on the chart. |
+| `highlighted-hours` | number[]? | `[]` | When using `precision = hour` set this array to the hours that should be highlighted. Make sure to also use the `grid` prop on the chart. |
+| `font` | string | `"Helvetica"`| Font family of the chart. |
+| `label-column-title` | string? | `''` | If specified, a dedicated column for the row labels will be rendered on the left side of the graph. The specified title is displayed in the upper left corner, as the column's header. |
+| `label-column-width` | string? | `150px` | Width of the column containing the row labels (if `label-column-title` specified) |
+| `showDayName` | boolean? | `true` | Adds the Day name to the timeunit axis when in `day` or `date` mode |
+| `dayNameLength` | string? | `short` | Sets whether the day name is short or long eg. 'Fri' or 'Friday'. Possible values: `short`, `long` |
+| `locale` | string? | `en-GB` | Used when getting the day name only. |
+| `allowRightClickDragging` | boolean? | `false` | Enable or disable the ability to drag bars when right-clicking a bar. Useful if you want to use the context menu and prevent accidental bar movements. |
+| `disableDragging` | boolean? | `false` | Disable dragging for all bars in the chart. |
+| `showLabelAsTooltipTitle` | boolean? | `true` | Toggles showing each bar item's label as the title in the hover tooltip. Make sure to sanitize your labels. |
 
 
 ## Custom Events

--- a/docs/GGanttChart.md
+++ b/docs/GGanttChart.md
@@ -30,6 +30,7 @@ The main component of Vue Ganttastic. Represents an entire chart and is meant to
 | `locale` | string? | `en-GB` | Used when getting the day name only.
 | `allowRightClickDragging` | boolean? | `false` | Enable or disable the ability to drag bars when right-clicking a bar. Useful if you want to use the context menu and prevent accidental bar movements.
 | `disableDragging` | boolean? | `false` | Disable dragging for all bars in the chart.
+| `showLabelAsTooltipTitle` | boolean? | `true` | Toggles showing each bar item's label as the title in the hover tooltip. Make sure to sanitize your labels.
 
 
 ## Custom Events

--- a/docs/GGanttChart.md
+++ b/docs/GGanttChart.md
@@ -25,6 +25,7 @@ The main component of Vue Ganttastic. Represents an entire chart and is meant to
 | `showDayName` | boolean? | `true` | Adds the Day name to the timeunit axis when in `day` or `date` mode
 | `dayNameLength` | string? | `short` | Sets whether the day name is short or long eg. 'Fri' or 'Friday'. Possible values: `short`, `long`
 | `locale` | string? | 'en-GB' | Used when getting the day name only.
+| `allowRightClickDragging | boolean? | 'false' | Enable or disable the ability to drag bars when right-clicking a bar. Useful if you want to use the context menu and prevent accidental bar movements.
 
 
 ## Custom Events

--- a/docs/GGanttRow.md
+++ b/docs/GGanttRow.md
@@ -6,9 +6,9 @@ Represents a single row of the chart. It is meant to be a child component of `g-
 |-------------|---------|---------|------------------------------|
 | `id`        | `string, number` | | Used in the `click-label` event. 
 | `label`     |`string?`| `""`    | Text that is floating in the upper left corner of the row.
-| `bars`      |`GanttBarObject[]`|  | Array of objects, each representing a bar in this row. Any JavaScript/TypeScript object with a nested `ganttBarConfig` object with a unique `id` string property is compatible. The objects must also contain two properties which represent the start and end datetime of the bar. The names of those properties must be passed  to the `bar-start` and `bar-end` props of the `g-gantt-chart` parent.
-| `highlight-on-hover` | `boolean?` | `false` | Used for toggling a background color transition effect on mouse hover.
-| `disableDragging` | `boolean?` | `false` | Used to disable dragging on a per-row basis. You can still disable dragging on a per-bar basis by setting `immobile` in the `GanttBarConfig` object of your bar object. Note that bar bundles ignore the immobile flag. If you drag an immobile bar in a bundle, the dragging will be prevented. If you drag a mobile bar in the same bundle, the immobile bars will also move. You can disable dragging entirely by setting `disableDragging` at the Chart level.
+| `bars`      |`GanttBarObject[]`|  | Array of objects, each representing a bar in this row. Any JavaScript/TypeScript object with a nested `ganttBarConfig` object with a unique `id` string property is compatible. The objects must also contain two properties which represent the start and end datetime of the bar. The names of those properties must be passed  to the `bar-start` and `bar-end` props of the `g-gantt-chart` parent. |
+| `highlight-on-hover` | `boolean?` | `false` | Used for toggling a background color transition effect on mouse hover. |
+| `disableDragging` | `boolean?` | `false` | Used to disable dragging on a per-row basis. You can still disable dragging on a per-bar basis by setting `immobile` in the `GanttBarConfig` object of your bar object. Note that bar bundles ignore the immobile flag. If you drag an immobile bar in a bundle, the dragging will be prevented. If you drag a mobile bar in the same bundle, the immobile bars will also move. You can disable dragging entirely by setting `disableDragging` at the Chart level. |
   
 ## Custom Events
 | Event name                 | Event data                                                 |

--- a/docs/GGanttRow.md
+++ b/docs/GGanttRow.md
@@ -7,6 +7,7 @@ Represents a single row of the chart. It is meant to be a child component of `g-
 | `label`     |`string?`| `""`    | Text that is floating in the upper left corner of the row.
 | `bars`      |`GanttBarObject[]`|  | Array of objects, each representing a bar in this row. Any JavaScript/TypeScript object with a nested `ganttBarConfig` object with a unique `id` string property is compatible. The objects must also contain two properties which represent the start and end datetime of the bar. The names of those properties must be passed  to the `bar-start` and `bar-end` props of the `g-gantt-chart` parent.
 | `highlight-on-hover` | `boolean?` | `false` | Used for toggling a background color transition effect on mouse hover.
+| `disableDragging` | `boolean?` | `false` | Used to disable dragging on a per-row basis. You can still disable dragging on a per-bar basis by setting `immobile` in the `GanttBarConfig` object of your bar object. Note that bar bundles ignore the immobile flag. If you drag an immobile bar in a bundle, the dragging will be prevented. If you drag a mobile bar in the same bundle, the immobile bars will also move. You can disable dragging entirely by setting `disableDragging` at the Chart level.
   
 ## Custom Events
 | Event name                 | Event data                                                 |

--- a/docs/GGanttRow.md
+++ b/docs/GGanttRow.md
@@ -4,6 +4,7 @@ Represents a single row of the chart. It is meant to be a child component of `g-
 ## Props
 | Prop        | Type    | Default | Description                  |
 |-------------|---------|---------|------------------------------|
+| `id`        | `string, number` | | Used in the `click-label` event. 
 | `label`     |`string?`| `""`    | Text that is floating in the upper left corner of the row.
 | `bars`      |`GanttBarObject[]`|  | Array of objects, each representing a bar in this row. Any JavaScript/TypeScript object with a nested `ganttBarConfig` object with a unique `id` string property is compatible. The objects must also contain two properties which represent the start and end datetime of the bar. The names of those properties must be passed  to the `bar-start` and `bar-end` props of the `g-gantt-chart` parent.
 | `highlight-on-hover` | `boolean?` | `false` | Used for toggling a background color transition effect on mouse hover.
@@ -13,6 +14,7 @@ Represents a single row of the chart. It is meant to be a child component of `g-
 | Event name                 | Event data                                                 |
 |----------------------------|------------------------------------------------------------|
 | `drop`                     | `{ e: MouseEvent, datetime: string}`                       |
+| `click-label` | `{ e: MouseEvent, label: string, id?: string | number }` |
 
 
 ## Slots

--- a/docs/common-use-cases.md
+++ b/docs/common-use-cases.md
@@ -125,7 +125,7 @@ const onDrop = (e: MouseEvent, datetime?: string) => {
 If the time-range (`chart-start` to `chart-end`) of your chart is very large, the displayed time units in the time axis might be too dense if the chart is not wide enough. You might want to specify the precision of the time axis accordingly. Use the `precision` prop of `g-gantt-chart` for this. Possible values are `hour`, `day`, `week` and `month`.
 
 ## Chart themes
-Vue Ganttastic ships with several pre-made color schemes that you may specify using the `color-scheme` prop of `g-gantt-chart`. [List of available color-schemes](https://infectoone.github.io/vue-ganttastic/GGanttChart.html#color-schemes)
+Vue Ganttastic ships with several pre-made color schemes that you may specify using the `color-scheme` prop of `g-gantt-chart`. [List of available color-schemes](https://zunnzunn.github.io/vue-ganttastic/GGanttChart.html#color-schemes)
 
 ## Locale
 Since Vue Ganttastic uses Day.js for all datetime manipulations, you can change the locale of Vue Ganttastic by [changing the global locale of Day.js](https://day.js.org/docs/en/i18n/changing-locale). You will usually do this in your `src/main.js` before you initialize the Ganttastic plugin.

--- a/docs/ganttBarConfig.md
+++ b/docs/ganttBarConfig.md
@@ -1,0 +1,20 @@
+# ganttBarConfig type
+The ganttBarConfig object allows customization of the bar objects and how they behave.
+
+You can add new properties as you wish, but the following properties already exist, and will change how your bars behave.
+
+## Properties
+| Property | Type | Description |
+| -------- | ---- | ----------- |
+| `id` | string | An identifier for the bar |
+| `label` | string? | The label for the bar. Can also be shown in the bar's tooltip if you set the `showLabelAsTooltipTitle` prop on the GGanttChart. Make sure to sanitize the value. |
+| `subtitle` | string? | If set, this will be appended to the tooltip. Make sure to sanitize the value. |
+| `html` | string? | Will render HTML immediately next to the label. Make sure to sanitize the value. |
+| `hasHandles` | boolean? | Toggles the bars drag handles allowing user to adjust start and end times independently. |
+| `immobile` | boolean? | Toggle an individual bar's ability to be dragged. Note that if an immobile bar is in a bundle with a mobile bar, dragging the mobile bar will also move the immobile bar. Immobile disables direct user interaction. |
+| `bundle` | string? | Group bars together such that dragging any bar in the same bundle will also move all other bars in that bundle. |
+| `pushOnOverlap` | boolean? | Prevents bars from overlapping each other by pushing other bars that would overlap out of the way. |
+| `dragLimitLeft` | number? | |
+| `dragLimitRight` | number? | |
+| `style` | Object<CSSProperties> | The style for each bar. |
+| `class` | string? | The class to be applied to each bar. |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -73,7 +73,7 @@ const row2BarList = ref([
 </script>
 ```
 
-The result shoud look like this:  
+The result should look like this:  
 <g-gantt-chart chart-start="2021-07-12 12:00" chart-end="2021-07-14 12:00" precision="hour" width="100%" bar-start="myBeginDate" bar-end="myEndDate"> <g-gantt-row label="My row 1" :bars="row1BarList"/>
 <g-gantt-row label="My row 2" :bars="row2BarList"/>
 </g-gantt-chart>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infectoone/vue-ganttastic",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "A simple and customizable Gantt chart component for Vue.js",
   "author": "Marko Zunic (@zunnzunn)",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infectoone/vue-ganttastic",
-  "version": "2.3.3",
+  "version": "2.3.2",
   "description": "A simple and customizable Gantt chart component for Vue.js",
   "author": "Marko Zunic (@zunnzunn)",
   "scripts": {

--- a/src/GanttPlayground.vue
+++ b/src/GanttPlayground.vue
@@ -27,9 +27,11 @@
     <g-gantt-row label="My another new row to test" highlight-on-hover :bars="bars2" />
     <g-gantt-row label="just another row to test gantt" highlight-on-hover :bars="bars3" />
     <g-gantt-row
+      id="some-unique-id"
       label="errors teach us, and debugging makes us stronger!"
       highlight-on-hover
       :bars="bars4"
+      @click-label="onLabelClick"
     />
   </g-gantt-chart>
 
@@ -47,6 +49,10 @@ const chartStart = ref(dayjs().startOf("day").format(format.value))
 const chartEnd = ref(
   dayjs(chartStart.value, format.value).add(3, "days").hour(12).format(format.value)
 )
+
+const onLabelClick = (e: MouseEvent) => {
+  console.log("click-label", e)
+}
 
 const bars1 = ref<GanttBarObject[]>([
   {

--- a/src/GanttPlayground.vue
+++ b/src/GanttPlayground.vue
@@ -98,6 +98,8 @@ const bars2 = ref([
       id: "9716981641",
       label: "Oh hey",
       subtitle: "I'm a subtitle",
+      html: "<strong>HTML</strong> content",
+      hasHandles: true,
       style: {
         background: "#69e064",
         borderRadius: "15px",

--- a/src/GanttPlayground.vue
+++ b/src/GanttPlayground.vue
@@ -2,8 +2,11 @@
   <g-gantt-chart
     :chart-start="chartStart"
     :chart-end="chartEnd"
-    precision="week"
+    precision="day"
     :row-height="40"
+    :highlighted-hours="[0, 1, 8, 22, 23]"
+    :highlighted-days-of-week="[0, 6]"
+    :highlighted-dates="[4, 6]"
     grid
     current-time
     width="100%"

--- a/src/GanttPlayground.vue
+++ b/src/GanttPlayground.vue
@@ -97,6 +97,7 @@ const bars2 = ref([
     ganttBarConfig: {
       id: "9716981641",
       label: "Oh hey",
+      subtitle: "I'm a subtitle",
       style: {
         background: "#69e064",
         borderRadius: "15px",

--- a/src/components/GGanttBarTooltip.vue
+++ b/src/components/GGanttBarTooltip.vue
@@ -20,11 +20,12 @@
 </template>
 
 <script setup lang="ts">
-import { computed, toRefs, ref, watch, nextTick } from "vue"
+import { computed, toRefs, ref, watch, nextTick, inject } from "vue"
 
 import type { GanttBarObject } from "../types"
 import useDayjsHelper from "../composables/useDayjsHelper.js"
 import provideConfig from "../provider/provideConfig.js"
+import { CHART_CONTAINER_KEY } from "../provider/symbols"
 
 const TOOLTIP_FORMATS = {
   hour: "HH:mm",
@@ -44,6 +45,8 @@ const props = defineProps<{
 const { bar } = toRefs(props)
 const { precision, font, barStart, barEnd, rowHeight } = provideConfig()
 
+const barContainerEl = inject(CHART_CONTAINER_KEY)
+
 const tooltipTop = ref("0px")
 const tooltipLeft = ref("0px")
 watch(
@@ -52,7 +55,7 @@ watch(
     await nextTick()
 
     const barId = bar?.value?.ganttBarConfig.id || ""
-    if (!barId) {
+    if (!barId || !barContainerEl?.value) {
       return
     }
 
@@ -61,7 +64,7 @@ watch(
       top: 0,
       left: 0
     }
-    const leftValue = Math.max(left, 10)
+    const leftValue = Math.max(left, barContainerEl?.value.getBoundingClientRect().left)
     tooltipTop.value = `${top + rowHeight.value - 10}px`
     tooltipLeft.value = `${leftValue}px`
   },

--- a/src/components/GGanttBarTooltip.vue
+++ b/src/components/GGanttBarTooltip.vue
@@ -12,7 +12,7 @@
       >
         <div class="g-gantt-tooltip-color-dot" :style="{ background: dotColor }" />
         <slot :bar="bar" :bar-start="barStartRaw" :bar-end="barEndRaw">
-          {{ tooltipContent }}
+          <span v-html="tooltipContent"></span>
         </slot>
       </div>
     </transition>
@@ -40,6 +40,7 @@ const DEFAULT_DOT_COLOR = "cadetblue"
 const props = defineProps<{
   bar: GanttBarObject | undefined
   modelValue: boolean
+  tooltipTitle?: boolean
 }>()
 
 const { bar } = toRefs(props)
@@ -85,7 +86,11 @@ const tooltipContent = computed(() => {
   const format = TOOLTIP_FORMATS[precision.value]
   const barStartFormatted = toDayjs(barStartRaw.value).format(format)
   const barEndFormatted = toDayjs(barEndRaw.value).format(format)
-  return `${barStartFormatted} \u2013 ${barEndFormatted}`
+  const title = props.tooltipTitle ? `${props?.bar?.ganttBarConfig.label} <br />` : ""
+  const subtitle = props?.bar?.ganttBarConfig.subtitle
+    ? `<br />${props.bar.ganttBarConfig.subtitle}`
+    : ""
+  return `${title}${barStartFormatted} \u2013 ${barEndFormatted}${subtitle}`
 })
 </script>
 

--- a/src/components/GGanttChart.vue
+++ b/src/components/GGanttChart.vue
@@ -100,6 +100,9 @@ export interface GGanttChartProps {
   font?: string
   labelColumnTitle?: string
   labelColumnWidth?: string
+  showDayName?: boolean
+  dayNameLength?: "short" | "long"
+  locale?: string
 }
 
 export type GGanttChartConfig = ToRefs<Required<GGanttChartProps>> & {
@@ -124,7 +127,10 @@ const props = withDefaults(defineProps<GGanttChartProps>(), {
   highlightedUnits: () => [],
   font: "inherit",
   labelColumnTitle: "",
-  labelColumnWidth: "150px"
+  labelColumnWidth: "150px",
+  showDayName: true,
+  dayNameLength: "short",
+  locale: "en-GB"
 })
 
 const emit = defineEmits<{

--- a/src/components/GGanttChart.vue
+++ b/src/components/GGanttChart.vue
@@ -97,6 +97,9 @@ export interface GGanttChartProps {
   noOverlap?: boolean
   rowHeight?: number
   highlightedUnits?: number[]
+  highlightedDates?: number[]
+  highlightedDaysOfWeek?: number[]
+  highlightedHours?: number[]
   font?: string
   labelColumnTitle?: string
   labelColumnWidth?: string
@@ -126,6 +129,9 @@ const props = withDefaults(defineProps<GGanttChartProps>(), {
   noOverlap: false,
   rowHeight: 40,
   highlightedUnits: () => [],
+  highlightedDates: () => [],
+  highlightedDaysOfWeek: () => [],
+  highlightedHours: () => [],
   font: "inherit",
   labelColumnTitle: "",
   labelColumnWidth: "150px",

--- a/src/components/GGanttChart.vue
+++ b/src/components/GGanttChart.vue
@@ -41,7 +41,11 @@
         </div>
       </div>
     </div>
-    <g-gantt-bar-tooltip :model-value="showTooltip || isDragging" :bar="tooltipBar">
+    <g-gantt-bar-tooltip
+      :model-value="showTooltip || isDragging"
+      :bar="tooltipBar"
+      :tooltipTitle="showLabelAsTooltipTitle"
+    >
       <template #default>
         <slot name="bar-tooltip" :bar="tooltipBar" />
       </template>
@@ -109,6 +113,7 @@ export interface GGanttChartProps {
   locale?: string
   allowRightClickDragging?: boolean
   disableDragging?: boolean
+  showLabelAsTooltipTitle?: boolean
 }
 
 export type GGanttChartConfig = ToRefs<Required<GGanttChartProps>> & {
@@ -141,7 +146,8 @@ const props = withDefaults(defineProps<GGanttChartProps>(), {
   dayNameLength: "short",
   locale: "en-GB",
   allowRightClickDragging: false,
-  disableDragging: false
+  disableDragging: false,
+  showLabelAsTooltipTitle: true
 })
 
 const emit = defineEmits<{

--- a/src/components/GGanttChart.vue
+++ b/src/components/GGanttChart.vue
@@ -107,6 +107,7 @@ export interface GGanttChartProps {
   dayNameLength?: "short" | "long"
   locale?: string
   allowRightClickDragging?: boolean
+  disableDragging?: boolean
 }
 
 export type GGanttChartConfig = ToRefs<Required<GGanttChartProps>> & {
@@ -138,7 +139,8 @@ const props = withDefaults(defineProps<GGanttChartProps>(), {
   showDayName: true,
   dayNameLength: "short",
   locale: "en-GB",
-  allowRightClickDragging: false
+  allowRightClickDragging: false,
+  disableDragging: false
 })
 
 const emit = defineEmits<{

--- a/src/components/GGanttChart.vue
+++ b/src/components/GGanttChart.vue
@@ -103,6 +103,7 @@ export interface GGanttChartProps {
   showDayName?: boolean
   dayNameLength?: "short" | "long"
   locale?: string
+  allowRightClickDragging?: boolean
 }
 
 export type GGanttChartConfig = ToRefs<Required<GGanttChartProps>> & {
@@ -130,7 +131,8 @@ const props = withDefaults(defineProps<GGanttChartProps>(), {
   labelColumnWidth: "150px",
   showDayName: true,
   dayNameLength: "short",
-  locale: "en-GB"
+  locale: "en-GB",
+  allowRightClickDragging: false
 })
 
 const emit = defineEmits<{

--- a/src/components/GGanttChart.vue
+++ b/src/components/GGanttChart.vue
@@ -77,6 +77,7 @@ import {
   CHART_ROWS_KEY,
   CONFIG_KEY,
   EMIT_BAR_EVENT_KEY,
+  CHART_CONTAINER_KEY,
   type ChartRow
 } from "../provider/symbols.js"
 
@@ -254,6 +255,7 @@ const emitBarEvent = (
 const ganttChart = ref<HTMLElement | null>(null)
 const chartSize = useElementSize(ganttChart)
 
+provide(CHART_CONTAINER_KEY, ganttChart)
 provide(CHART_ROWS_KEY, getChartRows)
 provide(CONFIG_KEY, {
   ...toRefs(props),

--- a/src/components/GGanttGrid.vue
+++ b/src/components/GGanttGrid.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="g-grid-container">
     <div
-      v-for="({ label, value, width }, index) in timeaxisUnits.lowerUnits"
+      v-for="({ label, date, width }, index) in timeaxisUnits.lowerUnits"
       :key="`${label}_${index}`"
       class="g-grid-line"
       :style="{
         width,
-        background: highlightedUnits?.includes(Number(value)) ? colors.hoverHighlight : undefined
+        background: shouldHighlight(date) ? colors.hoverHighlight : undefined
       }"
     />
   </div>
@@ -16,12 +16,30 @@
 import provideConfig from "../provider/provideConfig.js"
 import useTimeaxisUnits from "../composables/useTimeaxisUnits.js"
 
-defineProps<{
+const props = defineProps<{
   highlightedUnits?: number[]
 }>()
 
-const { colors } = provideConfig()
+const { colors, precision, highlightedDaysOfWeek, highlightedDates, highlightedHours } = provideConfig()
 const { timeaxisUnits } = useTimeaxisUnits()
+
+function shouldHighlight(date: Date): boolean {
+  if (precision.value === "hour") {
+    return highlightedHours?.value.includes(date.getHours())
+  } else if (precision.value !== "week" && precision.value !== "month") {
+    if (highlightedDaysOfWeek?.value.includes(date.getDay())) {
+      return true
+    }
+    if (highlightedDates?.value.includes(date.getDate())) {
+      return true
+    }
+    if (props.highlightedUnits?.includes(date.getHours())) {
+      return true
+    }
+  }
+
+  return false
+}
 </script>
 
 <style>

--- a/src/components/GGanttGrid.vue
+++ b/src/components/GGanttGrid.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="g-grid-container">
     <div
-      v-for="{ label, value, width } in timeaxisUnits.lowerUnits"
-      :key="label"
+      v-for="({ label, value, width }, index) in timeaxisUnits.lowerUnits"
+      :key="`${label}_${index}`"
       class="g-grid-line"
       :style="{
         width,

--- a/src/components/GGanttRow.vue
+++ b/src/components/GGanttRow.vue
@@ -14,7 +14,9 @@
       :style="{ background: colors.primary, color: colors.text }"
     >
       <slot name="label">
-        {{ label }}
+        <span @click="onLabelClick">
+          {{ label }}
+        </span>
       </slot>
     </div>
     <div ref="barContainer" class="g-gantt-row-bars-container" v-bind="$attrs">
@@ -41,10 +43,12 @@ const props = defineProps<{
   bars: GanttBarObject[]
   highlightOnHover?: boolean
   disableDragging?: boolean
+  id?: string | number
 }>()
 
 const emit = defineEmits<{
   (e: "drop", value: { e: MouseEvent; datetime: string | Date }): void
+  (e: "click-label", value: { e: MouseEvent; label: string; id?: string | number }): void
 }>()
 
 const setImmobileFlags = () => {
@@ -84,6 +88,10 @@ const onDrop = (e: MouseEvent) => {
   const xPos = e.clientX - container.left
   const datetime = mapPositionToTime(xPos)
   emit("drop", { e, datetime })
+}
+
+const onLabelClick = (e: MouseEvent) => {
+  emit("click-label", { e, label: props.label, id: props.id })
 }
 
 const isBlank = (str: string) => {

--- a/src/components/GGanttRow.vue
+++ b/src/components/GGanttRow.vue
@@ -28,7 +28,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, type Ref, toRefs, computed, type StyleValue, provide } from "vue"
+import { ref, type Ref, toRefs, computed, type StyleValue, provide, onMounted } from "vue"
 
 import useTimePositionMapping from "../composables/useTimePositionMapping.js"
 import provideConfig from "../provider/provideConfig.js"
@@ -40,11 +40,24 @@ const props = defineProps<{
   label: string
   bars: GanttBarObject[]
   highlightOnHover?: boolean
+  disableDragging?: boolean
 }>()
 
 const emit = defineEmits<{
   (e: "drop", value: { e: MouseEvent; datetime: string | Date }): void
 }>()
+
+const setImmobileFlags = () => {
+  for (const bar of props.bars) {
+    if (!Object.prototype.hasOwnProperty.call(bar.ganttBarConfig, "immobile")) {
+      bar.ganttBarConfig.immobile = props.disableDragging
+    } else {
+      // if disableDragging is set to true, then override immobile flag
+      // if it isn't, then leave it as is
+      bar.ganttBarConfig.immobile = props.disableDragging || bar.ganttBarConfig.immobile
+    }
+  }
+}
 
 const { rowHeight, colors, labelColumnTitle } = provideConfig()
 const { highlightOnHover } = toRefs(props)
@@ -74,9 +87,12 @@ const onDrop = (e: MouseEvent) => {
 }
 
 const isBlank = (str: string) => {
-  return (!str || /^\s*$/.test(str))
+  return !str || /^\s*$/.test(str)
 }
 
+onMounted(() => {
+  setImmobileFlags()
+})
 </script>
 
 <style>

--- a/src/components/GGanttTimeaxis.vue
+++ b/src/components/GGanttTimeaxis.vue
@@ -3,7 +3,7 @@
     <div class="g-timeunits-container">
       <div
         v-for="({ label, value, date, width }, index) in timeaxisUnits.upperUnits"
-        :key="label"
+        :key="`${label}_${index}`"
         class="g-upper-timeunit"
         :style="{
           background: index % 2 === 0 ? colors.primary : colors.secondary,
@@ -20,7 +20,7 @@
     <div class="g-timeunits-container">
       <div
         v-for="({ label, value, date, width }, index) in timeaxisUnits.lowerUnits"
-        :key="label"
+        :key="`${label}_${index}`"
         class="g-timeunit"
         :style="{
           background: index % 2 === 0 ? colors.ternary : colors.quartenary,

--- a/src/components/GGanttTimeaxis.vue
+++ b/src/components/GGanttTimeaxis.vue
@@ -31,6 +31,7 @@
         }"
       >
         <slot name="timeunit" :label="label" :value="value" :date="date">
+          {{ shouldShowDayName ? date.toLocaleDateString(locale, { weekday: dayNameLength }) + " " : "" }}
           {{ label }}
         </slot>
         <div
@@ -44,11 +45,16 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from "vue"
 import provideConfig from "../provider/provideConfig.js"
 import useTimeaxisUnits from "../composables/useTimeaxisUnits.js"
 
-const { precision, colors } = provideConfig()
+const { precision, colors, showDayName, dayNameLength, locale } = provideConfig()
 const { timeaxisUnits } = useTimeaxisUnits()
+
+const shouldShowDayName = computed(() => {
+  return showDayName && (precision.value === "day" || precision.value === "date")
+})
 </script>
 
 <style>

--- a/src/composables/createBarDrag.ts
+++ b/src/composables/createBarDrag.ts
@@ -12,7 +12,7 @@ export default function createBarDrag(
   onEndDrag: (e: MouseEvent, bar: GanttBarObject) => void = () => null,
   config: GGanttChartConfig = provideConfig()
 ) {
-  const { barStart, barEnd, pushOnOverlap } = config
+  const { barStart, barEnd, pushOnOverlap, allowRightClickDragging } = config
 
   const isDragging = ref(false)
   let cursorOffsetX = 0
@@ -22,6 +22,11 @@ export default function createBarDrag(
   const { toDayjs } = useDayjsHelper(config)
 
   const initDrag = (e: MouseEvent) => {
+    if (!allowRightClickDragging.value && e.buttons === 2) {
+      // Do not allow dragging when right-clicking
+      return
+    }
+
     const barElement = document.getElementById(bar.ganttBarConfig.id)
     if (!barElement) {
       return

--- a/src/composables/createBarDrag.ts
+++ b/src/composables/createBarDrag.ts
@@ -12,7 +12,7 @@ export default function createBarDrag(
   onEndDrag: (e: MouseEvent, bar: GanttBarObject) => void = () => null,
   config: GGanttChartConfig = provideConfig()
 ) {
-  const { barStart, barEnd, pushOnOverlap, allowRightClickDragging } = config
+  const { barStart, barEnd, pushOnOverlap, allowRightClickDragging, disableDragging } = config
 
   const isDragging = ref(false)
   let cursorOffsetX = 0
@@ -22,6 +22,10 @@ export default function createBarDrag(
   const { toDayjs } = useDayjsHelper(config)
 
   const initDrag = (e: MouseEvent) => {
+    if (disableDragging.value) {
+      return
+    }
+
     if (!allowRightClickDragging.value && e.buttons === 2) {
       // Do not allow dragging when right-clicking
       return

--- a/src/provider/symbols.ts
+++ b/src/provider/symbols.ts
@@ -18,3 +18,6 @@ export const EMIT_BAR_EVENT_KEY = Symbol("EMIT_BAR_EVENT_KEY") as InjectionKey<E
 export const BAR_CONTAINER_KEY = Symbol("BAR_CONTAINER_KEY") as InjectionKey<
   Ref<HTMLElement | null>
 >
+export const CHART_CONTAINER_KEY = Symbol("CHART_CONTAINER_KEY") as InjectionKey<
+  Ref<HTMLElement | null>
+>

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ export type GanttBarObject = {
   ganttBarConfig: {
     id: string
     label?: string
+    subtitle?: string
     html?: string
     hasHandles?: boolean
     immobile?: boolean


### PR DESCRIPTION
[fix] Fix #91 duplicate key warning when switching to hour precision.
[feat] Adds day names to timeaxis when using day or date mode.
- New prop on GGanttChart: `showDayName`, boolean?, true

[feat] Adds new prop to enable/disable right-click bar dragging. Useful if you want to use the right-click context menu, but want to avoid accidental bar movements.
- New prop on GGanttChart: `allowRightClickDragging`, boolean?, false

[feat] fix #89 "Anyway to disable the drag and drop function?" by:
- New prop on GGanttChart: `disableDragging`, boolean?, false - toggles dragging for the entire chart.
- New prop on GGanttRow: `disableDragging`, boolean? - toggles dragging on a per-row basis
  - Bar config flag `immobile` still available on a per-bar basis - will be overridden if the row or chart prop is true.
  - Note: If a bar is in a bundle, dragging a bar which is in a row where dragging is not disabled, will override the disabled row.

[feat] Add new methods for highlighting dates and hours (which fixes #125 and fixes #83 and is re-working of #95)
- New prop on GGanttChart: `highlightedDates`, number[]?, [] - When `precision` is set to `day or date`, dates in array will be highlighted.
- New prop on GGanttChart: `highlightedDaysOfWeek`, number[]?, [] - When `precision` is set to `day or date`, weekday indexes in array will be highlighted. E.g. [0, 6] = highlight Sunday and Saturday. (Reworking of #95)
- New prop on GGanttChart: `highlightedHours`, number[]?, [] - When `precision` is set to `hour`, hours in array will be highlighted.

[fix] Fix #123 docs issue
[feat] merges pull request #128 (which fixes #127) by @oldru27 - Ensure bar label is in view when bar start and/or end is beyond viewable range.

[feat] Adds new click event for row labels (closes #116).
- New event on GGanttRow: `click-label`, {MouseEvent, label, id}
- Also adds new `id` prop for GGanttRow as that, along with the label, will be returned in the click event.

[feat] Optionally add a title and subtitle to the bar tooltips.
- New prop on GGanttChart: `showLabelAsTooltipTitle`, boolean?, true. When true, adds the bar label property followed by a line break to the bar tooltip.
- New property on `ganttBarConfig` type: `tooltipSubtitle`, string?, "". When provided, adds a line break and the value to the end of the bar tooltip.
  - Make sure to sanitize these values.
  - See updated docs

Updated docs, added new doc for ganttBarConfig to advise where pre-existing properties exist and how they affect the bars.